### PR TITLE
Add simple web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ python bot.py
 
 Server luistert standaard op `http://127.0.0.1:5000/`.
 
+## Webinterface
+
+Navigeer in je browser naar `http://127.0.0.1:5000/`. Vul een start- en
+einddatum in en klik op **Vraag inzichten** om direct het antwoord van de bot
+te zien. De belangrijkste statistieken en de gegenereerde AI-tekst worden in de
+pagina getoond.
+
 ## Voorbeeld‑call
 
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import os
 import json
 from datetime import datetime
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 from dotenv import load_dotenv
 
 # Google Analytics
@@ -137,6 +137,10 @@ Schrijf in het Nederlands, gestructureerd met koppen en bullets.
 # ======== 5. Flask-app ========
 
 app = Flask(__name__)
+
+@app.route("/")
+def index():
+    return render_template("index.html")
 
 @app.route("/insights", methods=["GET"])
 def insights():

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>Analytics AI Bot</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        label { display: block; margin-top: 1em; }
+        button { margin-top: 1em; }
+        pre { background: #f4f4f4; padding: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Analytics AI Bot</h1>
+    <form id="insightsForm">
+        <label>Startdatum:
+            <input type="date" name="start" required>
+        </label>
+        <label>Einddatum:
+            <input type="date" name="end" required>
+        </label>
+        <button type="submit">Vraag inzichten</button>
+    </form>
+    <h2>Resultaat</h2>
+    <pre id="result"></pre>
+    <script>
+        const form = document.getElementById('insightsForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const start = form.elements['start'].value;
+            const end = form.elements['end'].value;
+            const response = await fetch(`/insights?start=${start}&end=${end}`);
+            const data = await response.json();
+            const result = document.getElementById('result');
+            if (data.error) {
+                result.textContent = 'Fout: ' + data.error;
+            } else {
+                let text = `Google Analytics 4\n` +
+                           `Sessies: ${data.ga_metrics.sessions}\n` +
+                           `Bounce rate: ${data.ga_metrics.avg_bounce_rate}%\n\n` +
+                           `Facebook Ads\n` +
+                           `Impressies: ${data.fb_metrics.impressions}\n` +
+                           `Klikken: ${data.fb_metrics.clicks}\n` +
+                           `Kosten: €${data.fb_metrics.spend}\n` +
+                           `CTR: ${data.fb_metrics.ctr*100}%\n\n` +
+                           `${data.ai_insights}`;
+                result.textContent = text;
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal HTML page to request insights
- serve the web page from Flask
- mention the interface in the README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684298b8b85c8329b10b50a2d4ee1acc