### PR TITLE
Set default date range on interface

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,6 @@
 import os
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from flask import Flask, request, jsonify, render_template
 from dotenv import load_dotenv
 
@@ -140,7 +140,10 @@ app = Flask(__name__)
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    today = datetime.utcnow().date()
+    default_end = today.strftime("%Y-%m-%d")
+    default_start = (today - timedelta(days=30)).strftime("%Y-%m-%d")
+    return render_template("index.html", default_start=default_start, default_end=default_end)
 
 @app.route("/insights", methods=["GET"])
 def insights():

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,10 +14,10 @@
     <h1>Analytics AI Bot</h1>
     <form id="insightsForm">
         <label>Startdatum:
-            <input type="date" name="start" required>
+            <input type="date" name="start" required value="{{ default_start }}">
         </label>
         <label>Einddatum:
-            <input type="date" name="end" required>
+            <input type="date" name="end" required value="{{ default_end }}">
         </label>
         <button type="submit">Vraag inzichten</button>
     </form>


### PR DESCRIPTION
## Summary
- show start date defaulted to one month ago
- show end date defaulted to today

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6842a105ddfc8329b862e448a7bb2055