### PR TITLE
Add operator instruction feature

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -224,6 +224,31 @@ def insights():
         "ai_insights": ai_text,
     })
 
+
+@app.route("/operator", methods=["POST"])
+def operator():
+    data = request.get_json(silent=True)
+    if not data or not data.get("instruction"):
+        return jsonify({"error": "Ontbrekende 'instruction' in request body."}), 400
+
+    prompt = (
+        "Je bent een ervaren analytics specialist. "
+        "Voer de volgende opdracht uit of geef een concreet stappenplan: "
+        f"{data['instruction']}"
+    )
+    try:
+        response = openai_client.chat.completions.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+            max_tokens=500,
+        )
+        content = response.choices[0].message.content.strip()
+    except Exception as e:
+        return jsonify({"error": f"Fout bij OpenAI-aanroep: {e}"}), 500
+
+    return jsonify({"response": content})
+
 @app.route("/health", methods=["GET"])
 def health():
     return jsonify({"status": "ok"}), 200

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,13 @@
         <h2 class="mb-3">Resultaat</h2>
         <div id="result" class="bg-white p-3 border"></div>
 
+        <div id="operatorSection" class="mt-4" style="display: none;">
+            <h2 class="mb-3">Opdracht aan OpenAI operator</h2>
+            <textarea id="operatorInstruction" class="form-control mb-2" rows="3" placeholder="Beschrijf je opdracht"></textarea>
+            <button type="button" id="sendInstruction" class="btn btn-success">Verstuur</button>
+            <div id="operatorResult" class="mt-3 bg-white p-3 border"></div>
+        </div>
+
         <div class="modal fade" id="loadingModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content p-5 text-center">
@@ -50,6 +57,10 @@
         const form = document.getElementById('insightsForm');
         const propertiesDiv = document.getElementById('gaProperties');
         const loadingModal = new bootstrap.Modal(document.getElementById('loadingModal'));
+        const operatorSection = document.getElementById('operatorSection');
+        const operatorInstruction = document.getElementById('operatorInstruction');
+        const operatorResult = document.getElementById('operatorResult');
+        const sendInstruction = document.getElementById('sendInstruction');
 
         document.getElementById('addProperty').addEventListener('click', () => {
             const group = document.createElement('div');
@@ -94,9 +105,32 @@
                             `- CTR: ${data.fb_metrics.ctr*100}%\n\n` +
                             `${data.ai_insights}`;
                     result.innerHTML = marked.parse(text);
+                    operatorSection.style.display = 'block';
                 }
             } finally {
                 loadingModal.hide();
+            }
+        });
+
+        sendInstruction.addEventListener('click', async () => {
+            const instruction = operatorInstruction.value.trim();
+            if (!instruction) return;
+            sendInstruction.disabled = true;
+            operatorResult.textContent = 'Even geduld...';
+            try {
+                const response = await fetch('/operator', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ instruction })
+                });
+                const data = await response.json();
+                if (data.error) {
+                    operatorResult.textContent = 'Fout: ' + data.error;
+                } else {
+                    operatorResult.innerHTML = marked.parse(data.response);
+                }
+            } finally {
+                sendInstruction.disabled = false;
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- show an operator instruction form after insights appear
- implement `/operator` endpoint to forward instructions to OpenAI

## Testing
- `python -m py_compile bot.py`
- *(failure)* `python bot.py` *(missing Flask)*

------
https://chatgpt.com/codex/tasks/task_e_6842bac061a88329a5791064a636bab9